### PR TITLE
Fix: Incorrect parameter count for multi-dimensional arrays in bridge_sampler.CmdStanFit()

### DIFF
--- a/R/bridge_sampler.R
+++ b/R/bridge_sampler.R
@@ -258,17 +258,9 @@ bridge_sampler.CmdStanFit <- function(samples = NULL, repetitions = 1,
   cores <- .validate_cores(cores)
 
   samples_md <- samples$metadata()
-  upars <- samples$unconstrain_draws()
-
-  samples_dims <- c(
-    samples_md$stan_variable_sizes[!samples_md$stan_variables %in% c("lp__", "log_lik")] |>
-      unlist() |>
-      sum()
-    , samples_md$iter_sampling
-    , length(samples_md$id)
-  )
-
-  upars <- array(unlist(upars), dim = samples_dims)
+  upars <- samples$unconstrain_draws() # array: iter x chain x param
+  
+  upars <- aperm(upars, c(3, 1, 2)) # array: param x iter x chain
   upars_args <- .restructure_upars(upars, use_neff)
 
   bs_args <- list(


### PR DESCRIPTION
Hello, @crsh. 

Thank you for your work on the "bridgesampling" package for supporting CmdStanR. This PR fixes a bug where `bridge_sampler()` fails for CmdStanR models that contain multi-dimensional array parameters (e.g., array[N] vector[M] var).

# The problem
The issue seems to stem from how the number of model parameters is calculated. The current implementation uses 
```
samples_md$stan_variable_sizes[!samples_md$stan_variables %in% c("lp__", "log_lik")]  |> unlist() |> sum()
```
, which incorrectly calculates the total number of parameters for multi-dimensional arrays.

For instance, a parameter `array[10] vector[5] cla` has dimensions c(10, 5), which represents 50 parameters. However, `unlist(list(c(10, 5))) |> sum()` results in 15 (10 + 5), leading to a dimension mismatch and causing failure when feeding the row sample to calculate log_prob.


# Reproducible example (R code)

```
stan_model <- write_stan_file("
  data {
    int<lower=1> N_sch;
    int<lower=1> N_cla;
    int<lower=1> N_stu;
    int<lower=1> N;
    vector[N] y;
  }
  parameters {
    real mu; // overall mean
    vector[N_sch] sch; // school effects
    array[N_sch] vector[N_cla] cla; // class effects
    real<lower=0> sigma_sch; // school standard deviation
    real<lower=0> sigma_cla; // class standard deviation
    real<lower=0> sigma_err; // student effects
  }
  model {
    // priors
    mu ~ normal(0, 100);
    sigma_sch ~ cauchy(0, 5);
    sigma_cla ~ cauchy(0, 5);
    sigma_err ~ cauchy(0, 5);
    // level 3:
    sch ~ normal(0, sigma_sch);
    // level 2:
    for (i in 1:N_sch) {
      cla[i] ~ normal(0, sigma_cla);
    }
    // level 1:
    for (i in 1:N_sch) {
      for (j in 1:N_cla) {
        y[(i - 1) * N_cla * N_stu + (j - 1) * N_stu + 1:N_stu] ~ normal(mu + sch[i] + cla[i, j], sigma_err);
      }
    }
  }
")

mod <- cmdstan_model(stan_model, force_recompile = TRUE)

fit <- mod$sample(
  data = data,
  chains = 4,
  parallel_chains = 4,
  iter_warmup = 2000,
  iter_sampling = 2000,
  refresh = 500
)

bs <- bridge_sampler(fit)
```

The error message: 

```
Compiling additional model methods...
Iteration: 1
Warning messages:
1: 4000 of the 4000 log_prob() evaluations on the posterior draws produced -Inf/Inf. 
2: 4000 of the 4000 log_prob() evaluations on the proposal draws produced -Inf/Inf. 
Error in `out[!from@positive] <- -out[!from@positive]`:
! NAs are not allowed in subscripted assignments
```

Correct vs. Incorrect Parameter Count:

```
> fit$metadata()$model_params
Warning message:
In parse_Rd("C:/Users/u0159666/OneDrive/Projects/bridgesampling/man/bridge_sampler.Rd",  :
  C:/Users/u0159666/OneDrive/Projects/bridgesampling/man/bridge_sampler.Rd:172: unknown macro '\object'
 [1] "lp__"      "mu"        "sch[1]"    "sch[2]"    "sch[3]"    "sch[4]"    "sch[5]"    "sch[6]"    "sch[7]"    "sch[8]"   
[11] "sch[9]"    "sch[10]"   "cla[1,1]"  "cla[2,1]"  "cla[3,1]"  "cla[4,1]"  "cla[5,1]"  "cla[6,1]"  "cla[7,1]"  "cla[8,1]" 
[21] "cla[9,1]"  "cla[10,1]" "cla[1,2]"  "cla[2,2]"  "cla[3,2]"  "cla[4,2]"  "cla[5,2]"  "cla[6,2]"  "cla[7,2]"  "cla[8,2]" 
[31] "cla[9,2]"  "cla[10,2]" "cla[1,3]"  "cla[2,3]"  "cla[3,3]"  "cla[4,3]"  "cla[5,3]"  "cla[6,3]"  "cla[7,3]"  "cla[8,3]" 
[41] "cla[9,3]"  "cla[10,3]" "cla[1,4]"  "cla[2,4]"  "cla[3,4]"  "cla[4,4]"  "cla[5,4]"  "cla[6,4]"  "cla[7,4]"  "cla[8,4]" 
[51] "cla[9,4]"  "cla[10,4]" "cla[1,5]"  "cla[2,5]"  "cla[3,5]"  "cla[4,5]"  "cla[5,5]"  "cla[6,5]"  "cla[7,5]"  "cla[8,5]" 
[61] "cla[9,5]"  "cla[10,5]" "sigma_sch" "sigma_cla" "sigma_err"
> length(fit$metadata()$model_params) - 1
[1] 64
> fit$metadata()$stan_variable_sizes
$lp__
[1] 1

$mu
[1] 1

$sch
[1] 10

$cla
[1] 10  5

$sigma_sch
[1] 1

$sigma_cla
[1] 1

$sigma_err
[1] 1
> fit$metadata()$stan_variable_sizes[!fit$metadata()$stan_variables %in% c("lp__", "log_lik")] |>
+       unlist() |>
+       sum()
[1] 29
```

In this example, the correct number of parameters is 64 instead of 29. 

# The fix 

I fixed the code (see commit) by changing the way to reorder the dimensions for unconstrained draws directly, so it doesn't need to recalculate the number of parameters and reshape the draw array additionally. 

Please let me know if you have any feedback or if any changes are needed. Thanks!
